### PR TITLE
fix ShouldNotImplDomObject

### DIFF
--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -78,13 +78,13 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
     };
 
     let mut params = proc_macro2::TokenStream::new();
-    params.append_separated(input.generics.type_params().map(|param| &param.ident), quote! {,});
+    params.append_separated(
+        input.generics.type_params().map(|param| &param.ident),
+        quote! {,},
+    );
 
     items.append_all(field_types.iter().enumerate().map(|(i, ty)| {
-        let s = syn::Ident::new(
-            &format!("S{i}"),
-            proc_macro2::Span::call_site(),
-        );
+        let s = syn::Ident::new(&format!("S{i}"), proc_macro2::Span::call_site());
         quote! {
             struct #s<#params>(#params);
 

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -60,32 +60,44 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
                 self.#first_field_name.init_reflector(obj);
             }
         }
+
+        // Generic trait with a blanket impl over `()` for all types.
+        // becomes ambiguous if impl
+        trait NoDomObjectInDomStruct<A> {
+            // Required for actually being able to reference the trait.
+            fn some_item() {}
+        }
+
+        impl<T: ?Sized> NoDomObjectInDomStruct<()> for T {}
+
+        // Used for the specialized impl when DomObject is implemented.
+        #[allow(dead_code)]
+        struct Invalid;
+        // forbids DomObject
+        impl<T> NoDomObjectInDomStruct<Invalid> for T where T: ?Sized + crate::DomObject {}
     };
 
     let mut params = proc_macro2::TokenStream::new();
     params.append_separated(input.generics.type_params().map(|param| &param.ident), quote! {,});
 
-    // For each field in the struct, we implement ShouldNotImplDomObject for a
-    // pair of all the type parameters of the DomObject and and the field type.
-    // This allows us to support parameterized DOM objects
-    // such as IteratorIterable<T>.
-    items.append_all(field_types.iter().map(|ty| {
+    items.append_all(field_types.iter().enumerate().map(|(i, ty)| {
+        let s = syn::Ident::new(
+            &format!("S{i}"),
+            proc_macro2::Span::call_site(),
+        );
         quote! {
-            impl #impl_generics ShouldNotImplDomObject for ((#params), #ty) #where_clause {}
+            struct #s<#params>(#params);
+
+            impl #impl_generics #s<#params> #where_clause {
+                fn f() {
+                    // If there is only one specialized trait impl, type inference with
+                    // `_` can be resolved and this can compile. Fails to compile if
+                    // ty implements `NoDomObjectInDomStruct<Invalid>`.
+                    let _ = <#ty as NoDomObjectInDomStruct<_>>::some_item;
+                }
+            }
         }
     }));
-
-    let mut generics = input.generics.clone();
-    generics.params.push(parse_quote!(
-        __T: crate::DomObject
-    ));
-
-    let (impl_generics, _, where_clause) = generics.split_for_impl();
-
-    items.append_all(quote! {
-        trait ShouldNotImplDomObject {}
-        impl #impl_generics ShouldNotImplDomObject for ((#params), __T) #where_clause {}
-    });
 
     let dummy_const = syn::Ident::new(
         &format!("_IMPL_DOMOBJECT_FOR_{}", name),


### PR DESCRIPTION
got over `IterableIterator` and over orphan rules by using same trait trick as in `NoTraceOnJSTraceable`, but this time adapted for generics. I also manually tested that it fails when it needs to.